### PR TITLE
remove `bottle :unneeded` as it is now deprecated

### DIFF
--- a/Formula/serve.rb
+++ b/Formula/serve.rb
@@ -3,7 +3,6 @@ class Serve < Formula
   desc "serve is a static http server anywhere you need one."
   homepage "https://github.com/syntaqx/serve"
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/syntaqx/serve/releases/download/v0.5.0/serve_0.5.0_macos_x86_64.tar.gz"


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the syntaqx/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/syntaqx/homebrew-tap/Formula/serve.rb:6
```